### PR TITLE
Overflow x on output cards

### DIFF
--- a/src-backend/cardManager.ts
+++ b/src-backend/cardManager.ts
@@ -1,4 +1,4 @@
-import { Card, CardOutput } from 'vscode-ipe-types';
+import { Card, CardOutput } from 'neuron-ipe-types';
 import * as path from "path";
 import * as fs from "fs";
 import * as vscode from 'vscode';

--- a/src-backend/contentHelpers.ts
+++ b/src-backend/contentHelpers.ts
@@ -1,5 +1,5 @@
 import { JSONValue, JSONObject, JSONArray } from '@phosphor/coreutils';
-import {Card, CardOutput} from 'vscode-ipe-types';
+import {Card, CardOutput} from 'neuron-ipe-types';
 import { Kernel, ServerConnection, KernelMessage } from '@jupyterlab/services';
 
 import * as vscode from 'vscode';

--- a/src-backend/extension.ts
+++ b/src-backend/extension.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 import { WebviewController } from "./webviewController";
 import { Interpreter } from "./interpreter";
 import { UserInteraction } from "./userInteraction";

--- a/src-backend/interpreter.ts
+++ b/src-backend/interpreter.ts
@@ -1,6 +1,6 @@
 import { Kernel, ServerConnection, KernelMessage } from '@jupyterlab/services';
 import { JSONValue, JSONObject } from '@phosphor/coreutils';
-import {Card, CardOutput} from 'vscode-ipe-types';
+import {Card, CardOutput} from 'neuron-ipe-types';
 import { ContentHelpers } from './contentHelpers';
 
 import * as vscode from 'vscode';

--- a/src-backend/webviewController.ts
+++ b/src-backend/webviewController.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 import {Event, EventEmitter} from "vscode";
 
 /**

--- a/src-frontend/src/app/app.component.ts
+++ b/src-frontend/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { ExtensionService } from './classes/extension.service';
-import { Card, CardOutput } from 'vscode-ipe-types';
+import { Card, CardOutput } from 'neuron-ipe-types';
 import { RegexService } from './classes/regex.service';
 
 

--- a/src-frontend/src/app/card/card.component.css
+++ b/src-frontend/src/app/card/card.component.css
@@ -66,6 +66,7 @@ pre {
 .card-output {
   padding: 0 6px;
   user-select: text;
+  overflow-x: scroll;
 }
 .output-plain {
   word-wrap: break-word;

--- a/src-frontend/src/app/card/card.component.ts
+++ b/src-frontend/src/app/card/card.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, Output, EventEmitter} from '@angular/core';
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 
 import {
   trigger,

--- a/src-frontend/src/app/classes/extension.service.ts
+++ b/src-frontend/src/app/classes/extension.service.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, Injectable} from '@angular/core';
 
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 declare var acquireVsCodeApi;
 
 @Injectable()

--- a/src-frontend/src/app/testing/card.component.spec.ts
+++ b/src-frontend/src/app/testing/card.component.spec.ts
@@ -8,7 +8,7 @@ import { PreviewPipe } from '../classes/preview.pipe'
 import { MapComponent } from '../map/map.component';
 import { AnsiColorizePipe } from '../classes/ansi-colorize.pipe';
 import { RegexService } from '../classes/regex.service';
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {MathComponent} from '../math/math.component'
 import { MarkdownModule } from 'ngx-markdown';

--- a/src-frontend/src/app/testing/custom-markdown.component.spec.ts
+++ b/src-frontend/src/app/testing/custom-markdown.component.spec.ts
@@ -8,7 +8,7 @@ import { PreviewPipe } from '../classes/preview.pipe'
 import { MapComponent } from '../map/map.component';
 import { AnsiColorizePipe } from '../classes/ansi-colorize.pipe';
 import { RegexService } from '../classes/regex.service';
-import { Card } from 'vscode-ipe-types';
+import { Card } from 'neuron-ipe-types';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MathComponent } from '../math/math.component'
 import { MarkdownModule } from 'ngx-markdown';


### PR DESCRIPTION
Big datatables were flowing over and couldn't be seen, so I changed the style to allow scrolling on overflow-x. 

This includes the fix for #168, but as soon as #160 is merged, the fix will no longer be needed. Kinda new to OSS contribution so lmk what's the right way to handle this! :)